### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Note: Listed below are only a few courses provided by each platform. Please visi
 
 - [Code Palace](https://www.youtube.com/channel/UCuudpdbKmQWq2PPzYgVCWlA)
 
-- [AndroidDevs](https://www.youtube.com/channel/UCKNTZMRHPLXfqlbdOI7mCkg)
+- [Philipp Lackner](https://www.youtube.com/channel/UCKNTZMRHPLXfqlbdOI7mCkg)
 
 - [Simplified Coding](https://www.youtube.com/user/SimplifiedCoding)
 


### PR DESCRIPTION
Philipp was change the channel name because AndroidDev is similar to AndroidDevs and this name owns by Google.