### PR TITLE
Fixes broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ Note: Listed below are only a few courses provided by each platform. Please visi
 
 - [Egor's Blog](https://blog.egorand.me/) - Android, Kotlin and other tech
 
-- [Sachin's Blog)(https://iamsachinrajput.medium.com/) - Articles on Android, Kotlin based on real app development experiences.
+- [Sachin's Blog](https://iamsachinrajput.medium.com/) - Articles on Android, Kotlin based on real app development experiences.
 
 - [Dropbox Tech Mobile](https://dropbox.tech/mobile) - Articles on Mobile development by Dropbox engineers.
 


### PR DESCRIPTION
"Sachin's Blog" used `)` instead of `[` for the link, which is invalid markdown syntax.

Here's the rich diff:
![image](https://user-images.githubusercontent.com/12380876/203415976-9e340675-86aa-4fb6-9b00-2b11ebfc4363.png)
