### PR TITLE
Include Jetpack Compose components link

### DIFF
--- a/README.md
+++ b/README.md
@@ -898,6 +898,8 @@ Creating Working Applications.
 
 - [Gradle distributionUrl versions](https://services.gradle.org/distributions/) - services.gradle.org/distributions/
 
+- [Jetpack Compose Components list](https://www.composables.com/components) – A list of all components you can use in Jetpack Compose.
+
 #### ZH
 
 - [xitu](http://e.xitu.io/) - Open-source Projects.


### PR DESCRIPTION
Added a link to the [Jetpack Compose Components list](https://www.composables.com/components).

The page gained some interest in the Android community so I figured I should share it here.